### PR TITLE
Refactored to use parameterized SQL APIs (#1)

### DIFF
--- a/JtProject/src/main/java/com/jtspringproject/JtSpringProject/controller/AdminController.java
+++ b/JtProject/src/main/java/com/jtspringproject/JtSpringProject/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.jtspringproject.JtSpringProject.controller;
 
 import java.sql.*;
+import java.sql.PreparedStatement;
 import java.util.List;
 
 import javax.servlet.http.Cookie;
@@ -234,8 +235,9 @@ public class AdminController {
 		{
 			Class.forName("com.mysql.jdbc.Driver");
 			Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/ecommjava","root","");
-			Statement stmt = con.createStatement();
-			ResultSet rst = stmt.executeQuery("select * from users where username = '"+usernameforclass+"';");
+			PreparedStatement stmt = con.prepareStatement("select * from users where username = ?"+";");
+			stmt.setString(1, usernameforclass);
+			ResultSet rst = stmt.execute();
 			
 			if(rst.next())
 			{


### PR DESCRIPTION
This change refactors SQL statements to be parameterized, rather than built by hand.

Without parameterization, developers must remember to escape inputs using the rules for that database. It's usually buggy, at the least -- and sometimes vulnerable.

Our changes look something like this:

```diff
- Statement stmt = connection.createStatement();
- ResultSet rs = stmt.executeQuery("SELECT * FROM users WHERE name = '" + user + "'");
+ PreparedStatement stmt = connection.prepareStatement("SELECT * FROM users WHERE name = ?");
+ stmt.setString(1, user);
+ ResultSet rs = stmt.executeQuery();
```

<details>
  <summary>More reading</summary>

  * [https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
  * [https://cwe.mitre.org/data/definitions/89.html](https://cwe.mitre.org/data/definitions/89.html)
</details>


Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/sql-parameterizer](https://docs.pixee.ai/codemods/java/pixee_java_sql-parameterizer)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2FE-commerce-project-springBoot%7Cf32fc7d902e4ca94a4e8321caf58da70bcfdd265)

<!--{"type":"DRIP","codemod":"pixee:java/sql-parameterizer"}-->