### PR TITLE
Fixed Update button in Products page

### DIFF
--- a/JtProject/src/main/webapp/views/productsUpdate.jsp
+++ b/JtProject/src/main/webapp/views/productsUpdate.jsp
@@ -44,7 +44,6 @@
 			</div>
 		</div>
 	</nav><br>
-	<c:forEach var="product" items="products">
 	<div class="jumbotron container border border-info">
 		<h3>Update Existing Product</h3>
 		<form action="/products/update/${product.id}" method="post">
@@ -114,7 +113,6 @@
 			</div>
 		</form>
 	</div>
-	</c:forEach>
 
 	<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
 		integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"


### PR DESCRIPTION
Closes #48 

### Problem:
products page update button does not work

### Cause:

- when the update button in products page is clicked, it triggers `updateproduct()` in `AdminController.java`
  - updateproduct() creates a new "productsUpdate" ModelAndView and **adds a product object** and list of category objects to the ModelAndView
  - the resulting ModelAndView is displayed to the user

- the ModelAndView can be found in `productsUpdate.jsp`
  - the code `<c:forEach var="product" items="products">` is causing the error to be thrown since it should be items="${products}" and not a string

![server error](https://github.com/jaygajera17/E-commerce-project-springBoot/assets/98062538/f7fc2efb-0060-40b3-a98e-1a58d475b2b3)

  - there is no need for the forEach loop since we never add a list of products to the ModelAndView, only **one product object**
    - keeping the forEach loop results in blank page, since we never pass in a list of products

### Fix:

- in `productsUpdate.jsp`, removed the forEach loop completely, since we add one product to the view and not a list of products

---

### Testing

![fix1](https://github.com/jaygajera17/E-commerce-project-springBoot/assets/98062538/c3a0358f-7ad7-434f-8c02-b276f5a74f4c)

![fix2](https://github.com/jaygajera17/E-commerce-project-springBoot/assets/98062538/85f9df9b-3852-4cad-bef4-5c544bbd247e)




