### PR TITLE
fix: move PasswordEncoder to separate config to resolve circular depndency

### DIFF
--- a/src/main/java/com/jtspringproject/JtSpringProject/configuration/PasswordEncoderConfig.java
+++ b/src/main/java/com/jtspringproject/JtSpringProject/configuration/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.jtspringproject.JtSpringProject.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/jtspringproject/JtSpringProject/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/jtspringproject/JtSpringProject/configuration/SecurityConfiguration.java
@@ -6,8 +6,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 

--- a/src/main/java/com/jtspringproject/JtSpringProject/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/jtspringproject/JtSpringProject/configuration/SecurityConfiguration.java
@@ -99,8 +99,5 @@ public class SecurityConfiguration {
 		};
 	}
 
-	@Bean
-	PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+
 }

--- a/src/main/java/com/jtspringproject/JtSpringProject/repository/CartProductRepository.java
+++ b/src/main/java/com/jtspringproject/JtSpringProject/repository/CartProductRepository.java
@@ -1,8 +1,0 @@
-package com.jtspringproject.JtSpringProject.repository;
-
-import com.jtspringproject.JtSpringProject.models.CartProduct;
-import com.jtspringproject.JtSpringProject.models.CartProductId;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CartProductRepository extends JpaRepository<CartProduct, CartProductId> {
-}


### PR DESCRIPTION
Closes #150 

## Problem
The application failed to start due to a circular dependency:
SecurityConfiguration → UserService → PasswordEncoder → SecurityConfiguration

The PasswordEncoder bean was defined inside SecurityConfiguration, which 
itself depended on UserService, which depended on PasswordEncoder — 
creating a cycle Spring could not resolve.

## Fix
Moved the PasswordEncoder bean into a new dedicated class 
PasswordEncoderConfig.java, breaking the circular dependency chain.

## Testing
Application starts successfully after this change.